### PR TITLE
ConnectX4-LX vendor id added

### DIFF
--- a/deployment_scripts/puppet/manifests/controller.pp
+++ b/deployment_scripts/puppet/manifests/controller.pp
@@ -13,7 +13,7 @@ if ( $mlnx['driver'] == 'mlx4_en' and $mlnx['mlnx_qos'] ) {
 }
 
 if ($mlnx['sriov']) {
-  $pci_vendor_devices = '15b3:1004,15b3:1014,8086:10ca'
+  $pci_vendor_devices = '15b3:1004,15b3:1014,8086:10ca,15b3:1016'
   $agent_required = 'True'
   class { 'mellanox_openstack::controller_sriov' :
     eswitch_vnic_type           => $eswitch_vnic_type,


### PR DESCRIPTION
In order for sr-iov to work with ConnectX4-LX on Fuel, I added the vendor id to the supported pci vendor devices 
